### PR TITLE
MBS-8820: User specific creation and archive download

### DIFF
--- a/classes/Report.php
+++ b/classes/Report.php
@@ -129,22 +129,25 @@ class Report {
     /**
      * Get all attempts for all users inside this quiz, excluding previews
      *
+     * @param int $userid - If set, only the attempts of the given user are included.
      * @return array Array of all attempt IDs together with the userid that were
      * made inside this quiz. Indexed by attemptid.
      *
      * @throws \dml_exception
      */
-    public function get_attempts(): array {
+    public function get_attempts($userid = 0): array {
         global $DB;
 
-        return $DB->get_records_sql(
-            "SELECT id AS attemptid, userid " .
-            "FROM {quiz_attempts} " .
-            "WHERE preview = 0 AND quiz = :quizid",
-            [
-                "quizid" => $this->quiz->id,
-            ]
-        );
+        $conditions = [
+            'quiz' => $this->quiz->id,
+            'preview' => 0,
+        ];
+
+        if(!empty($userid)) {
+            $conditions['userid'] = $userid;
+        }
+
+        return $DB->get_records('quiz_attempts', $conditions, '', 'id AS attemptid, userid');
     }
 
     /**
@@ -586,22 +589,22 @@ class Report {
                 nav.navbar {
                     display: none !important;
                 }
-                
+
                 footer {
                     display: none !important;
                 }
-                
+
                 div#page {
                     margin-top: 0 !important;
                     padding-left: 0 !important;
                     padding-right: 0 !important;
                     height: initial !important;
                 }
-                
+
                 div#page-wrapper {
                     height: initial !important;
                 }
-                
+
                 .stackinputerror {
                     display: none !important;
                 }

--- a/db/access.php
+++ b/db/access.php
@@ -63,4 +63,15 @@ $capabilities = [
         'contextlevel' => CONTEXT_SYSTEM,
         'archetypes' => [],
     ],
+    // Capability to use the webservice. Required for the webservice user.
+    'mod/quiz_archiver:getownarchive' => [
+        'riskbitmask' => (RISK_PERSONAL),
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'student' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 ];

--- a/lib.php
+++ b/lib.php
@@ -46,9 +46,16 @@ use quiz_archiver\FileManager;
 function quiz_archiver_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = []) {
     // Check permissions.
     require_login($course, false, $cm);
-    require_capability('mod/quiz:grade', $context);
-    require_capability('quiz/grading:viewstudentnames', $context);
-    require_capability('quiz/grading:viewidnumber', $context);
+
+    if (!((
+    has_capability('mod/quiz:grade', $context)
+    && has_capability('quiz/grading:viewstudentnames', $context)
+    && has_capability('quiz/grading:viewidnumber', $context)
+    ) ||
+    has_capability('mod/quiz_archiver:getownarchive', $context)
+    )) {
+        throw new moodle_exception("You have not the capability to download the archive file.");
+    }
 
     // Validate course
     if ($args[1] !== $course->id) {

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'quiz_archiver';
 $plugin->release = '1.2.4';
-$plugin->version = 2024021901;
+$plugin->version = 2024021902;
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 403];
 //$plugin->incompatible = 402;


### PR DESCRIPTION
This PR makes it possible to create archives for a single user only if the UserID is specified. 

It also restricts the view of the job overview table so that only archives created by the respective user are displayed. 

(Here you could think about an extension so that users with certain authorisations could continue to see all archives or at least the archives of other users with the same rights)