### PR TITLE
Feature: Improve status refresh and overall visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improve status and error notifications for all actions (job creation, deletion, ...)
 - Prevent form data resubmission on page reload
+- Add tooltip to archive overview refresh button and list time of last page refresh
 
 
 ## Version 1.4.0 (2024072900)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Improve status and error notifications for all actions (job creation, deletion, ...)
 - Prevent form data resubmission on page reload
 - Add tooltip to archive overview refresh button and list time of last page refresh
+- Improve visual presentation of the quiz archive overview table
+- Improve visual presentation of the quiz archive creation form
 
 
 ## Version 1.4.0 (2024072900)

--- a/classes/output/job_overview_table.php
+++ b/classes/output/job_overview_table.php
@@ -57,8 +57,8 @@ class job_overview_table extends \table_sql {
             'timecreated',
             'user',
             'jobid',
-            'status',
             'filesize',
+            'status',
             'actions',
         ]);
 
@@ -66,8 +66,8 @@ class job_overview_table extends \table_sql {
             get_string('task_starttime', 'admin'),
             get_string('user'),
             get_string('jobid', 'quiz_archiver'),
-            get_string('status'),
             get_string('size'),
+            get_string('status'),
             '',
         ]);
 

--- a/classes/output/job_overview_table.php
+++ b/classes/output/job_overview_table.php
@@ -55,18 +55,18 @@ class job_overview_table extends \table_sql {
         parent::__construct($uniqueid);
         $this->define_columns([
             'timecreated',
-            'status',
             'user',
             'jobid',
+            'status',
             'filesize',
             'actions',
         ]);
 
         $this->define_headers([
             get_string('task_starttime', 'admin'),
-            get_string('status'),
             get_string('user'),
             get_string('jobid', 'quiz_archiver'),
+            get_string('status'),
             get_string('size'),
             '',
         ]);

--- a/lang/de/quiz_archiver.php
+++ b/lang/de/quiz_archiver.php
@@ -100,6 +100,7 @@ $string['export_report_section_history_help'] = 'Antworthistorie für alle Testf
 $string['export_report_section_attachments'] = 'Dateiabgaben einschließen';
 $string['export_report_section_attachments_help'] = 'Alle Dateiabgaben (z.B. von Freitextaufgaben) im Archiv einschließen. Warnung: Dies kann die Archivgröße erheblich erhöhen.';
 $string['job_overview'] = 'Testarchive';
+$string['last_updated'] = 'Zuletzt aktualisiert';
 $string['num_attempts'] = 'Anzahl der Testversuche';
 
 // Job creation form: Filename pattern.

--- a/lang/en/quiz_archiver.php
+++ b/lang/en/quiz_archiver.php
@@ -100,6 +100,7 @@ $string['export_report_section_history_help'] = 'Display the answer history for 
 $string['export_report_section_attachments'] = 'Include file attachments';
 $string['export_report_section_attachments_help'] = 'Include all file attachments (e.g., essay file submissions) inside the archive. Warning: This can significantly increase the archive size.';
 $string['job_overview'] = 'Archives';
+$string['last_updated'] = 'Last updated';
 $string['num_attempts'] = 'Number of attempts';
 
 // Job creation form: Filename pattern.

--- a/report.php
+++ b/report.php
@@ -172,6 +172,7 @@ class quiz_archiver_report extends report_base {
             'baseurl' => $this->base_url(),
             'jobOverviewTable' => $jobtblhtml,
             'jobs' => $this->generate_job_metadata_tplctx(),
+            'time' => time(),
         ]);
 
         return true;

--- a/report.php
+++ b/report.php
@@ -152,12 +152,11 @@ class quiz_archiver_report extends report_base {
             return true;
         }
 
-        // Render quiz archive form. Logic is handled in handle_posted_forms() above.
+        // Quiz archive form. Logic is handled in handle_posted_forms() above.
         $archivequizform = new archive_quiz_form(
             $this->quiz->name,
             count($this->report->get_attempts())
         );
-        $archivequizform->display();
 
         // Job overview table.
         $jobtbl = new job_overview_table('job_overview_table', $this->course->id, $this->cm->id, $this->quiz->id);
@@ -169,6 +168,7 @@ class quiz_archiver_report extends report_base {
 
         // Render output.
         echo $OUTPUT->render_from_template('quiz_archiver/overview', [
+            'archiveQuizForm' => $archivequizform->render(),
             'baseurl' => $this->base_url(),
             'jobOverviewTable' => $jobtblhtml,
             'jobs' => $this->generate_job_metadata_tplctx(),

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,40 @@
+/* This file is part of Moodle - http://moodle.org/
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Custom style definitions for the quiz_archiver plugin.
+ *
+ * @copyright 2024 Niels Gandraß <niels@gandrass.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/* Archive creation form */
+.quiz_archiver-archive-quiz-form > form > fieldset:last-of-type {
+    border-bottom: 0 !important;
+}
+
+/* Job overview table */
+.quiz_archiver-job-overview-table > .pagination:nth-of-type(1) {
+    display: none !important;
+}
+
+.quiz_archiver-job-overview-table th {
+    border-top: 0 !important;
+}
+
+.quiz_archiver-job-overview-table th > a {
+    display: inline-block;
+}

--- a/styles.css
+++ b/styles.css
@@ -23,16 +23,16 @@
 
 /* Archive creation form */
 .quiz_archiver-archive-quiz-form > form > fieldset:last-of-type {
-    border-bottom: 0 !important;
+    border-bottom: 0;
 }
 
 /* Job overview table */
 .quiz_archiver-job-overview-table > .pagination:nth-of-type(1) {
-    display: none !important;
+    display: none;
 }
 
-.quiz_archiver-job-overview-table th {
-    border-top: 0 !important;
+.quiz_archiver-job-overview-table th.header {
+    border-top: 0;
 }
 
 .quiz_archiver-job-overview-table th > a {

--- a/templates/overview.mustache
+++ b/templates/overview.mustache
@@ -32,7 +32,8 @@
                 "jobid": "45edd9f6-3784-11ee-be56-0242ac120002",
                 "json": "{...}"
             }
-        ]
+        ],
+        "time": 0
     }
 }}
 
@@ -40,10 +41,20 @@
 {{#jobOverviewTable}}
 <h1>
     {{#str}} job_overview, quiz_archiver {{/str}}
-    <a href="{{{baseurl}}}" class="small mx-2" title="{{#str}} refresh, moodle {{/str}}">
+    <a
+        href="{{{baseurl}}}"
+        class="small mx-2"
+        title="{{#str}} refresh, moodle {{/str}}"
+        data-toggle="tooltip"
+        data-placement="right"
+    >
         <i class="fa fa-rotate-right"></i>
     </a>
 </h1>
+<div>
+    {{#str}} last_updated, quiz_archiver {{/str}}:
+    {{#userdate}} {{time}}, %T {{/userdate}}
+</div>
 <div>
     {{{jobOverviewTable}}}
 </div>

--- a/templates/overview.mustache
+++ b/templates/overview.mustache
@@ -21,6 +21,7 @@
 
     Example context (json):
     {
+        "archiveQuizForm": "<!-- Generated Moodle form HTML -->",
         "baseurl": "https://example.com/mod/quiz/archiver/",
         "jobOverviewTable": "<!-- Generated Moodle table HTML -->",
         "jobs": [
@@ -36,6 +37,11 @@
         "time": 0
     }
 }}
+
+{{! Quiz archive form }}
+<div class="quiz_archiver-archive-quiz-form mb-4">
+    {{{archiveQuizForm}}}
+</div>
 
 {{! List of existing archives }}
 {{#jobOverviewTable}}
@@ -55,7 +61,7 @@
     {{#str}} last_updated, quiz_archiver {{/str}}:
     {{#userdate}} {{time}}, %T {{/userdate}}
 </div>
-<div>
+<div class="quiz_archiver-job-overview-table">
     {{{jobOverviewTable}}}
 </div>
 


### PR DESCRIPTION
This pull request addresses #21

#### Changes
- Add tooltip to archive overview refresh button and list time of last page refresh
- Improve visual presentation of the quiz archive overview table
- Improve visual presentation of the quiz archive creation form

#### Screenshots
- The refresh button now has a proper tooltip.
![image](https://github.com/user-attachments/assets/fc25e77d-4bd9-4edd-a24f-bd9877f133ac)

- The time of the last refresh is displayed under the button so that a user more easily recognizes the connection between the button and the currency of the data displayed below.
![image](https://github.com/user-attachments/assets/8b258dcb-c5ba-4f52-8354-877a381cc987)

- The status column is now moved to the right. I did some tests and found the suggested column order to be both functional and visually appealing. This way, also colored parts are grouped together so the visual focus of the user does potentially not shift that strongly as before.
![Screenshot_20240812_175400](https://github.com/user-attachments/assets/596a7e41-e659-48e8-bf5a-250d65f5d570)

- All job status values now feature tooltips explaining the respective status.
![image](https://github.com/user-attachments/assets/92148da8-48f2-49ef-8a8b-3e21cd8122ba)
![image](https://github.com/user-attachments/assets/c91480cb-b984-4e07-8cd1-c9a70eaa31f5)

- I decided against moving the refresh button to another location. In my opinion an element should be positioned as close as possible to the part of a page that it affects. Since the table is potentially the only part of the page that changes during the refresh I'll keep the refresh button close to it.

- I decided against changing the color of the refresh button since the different status values are already displayed as distinctly colored status badges.
![image](https://github.com/user-attachments/assets/e63595f0-7fb7-4c98-8077-3a5e18def94b) ![image](https://github.com/user-attachments/assets/6ee29396-072a-4337-9b10-cd1425d1fd9e) ![image](https://github.com/user-attachments/assets/0ca3a9a7-e49f-4082-b82c-74eceeaf3974) ![image](https://github.com/user-attachments/assets/c2b7d88e-4708-4b1b-82f9-06c6641b4abb) ... and so on ...