### PR TITLE
Feature: Student ID number integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add student ID number to quiz attempt header
 - Add student ID number to exported `attempts_metadata.csv` file inside quiz archives
+- Allow student ID number to be used in attempt filename pattern as `${idnumber}`
 - Improve display of user firstname, lastname, and avatar in quiz attempt header
 - Improve display of empty values in quiz attempt header (e.g., feedback, idnumber, ...)
 - Fix name of `QUIZ_ARCHIVER_PREVENT_REDIRECT_TO_LOGIN` environment variable in archive worker documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version x.x.x (yyyymmddnn)
 
+- Add student ID number to quiz attempt header
+- Improve display of user firstname, lastname, and avatar in quiz attempt header
+- Improve display of empty values in quiz attempt header (e.g., feedback, idnumber, ...)
 - Fix name of `QUIZ_ARCHIVER_PREVENT_REDIRECT_TO_LOGIN` environment variable in archive worker documentation
 - Improve content spacing in docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Version x.x.x (yyyymmddnn)
 
 - Add student ID number to quiz attempt header
+- Add student ID number to exported `attempts_metadata.csv` file inside quiz archives
 - Improve display of user firstname, lastname, and avatar in quiz attempt header
 - Improve display of empty values in quiz attempt header (e.g., feedback, idnumber, ...)
 - Fix name of `QUIZ_ARCHIVER_PREVENT_REDIRECT_TO_LOGIN` environment variable in archive worker documentation
+- Fix single unit test suit execution command in developer documentation
 - Improve content spacing in docs
 
 

--- a/classes/ArchiveJob.php
+++ b/classes/ArchiveJob.php
@@ -114,6 +114,7 @@ class ArchiveJob {
         'username',
         'firstname',
         'lastname',
+        'idnumber',
         'timestart',
         'timefinish',
         'date',
@@ -1218,6 +1219,7 @@ class ArchiveJob {
             'username' => $userinfo->username,
             'firstname' => $userinfo->firstname,
             'lastname' => $userinfo->lastname,
+            'idnumber' => $userinfo->idnumber,
         ];
 
         // Substitute variables.

--- a/classes/Report.php
+++ b/classes/Report.php
@@ -395,7 +395,7 @@ class Report {
         if ($sections['header']) {
             $quizheaderdata = [];
 
-            // User name and link
+            // User name and link.
             $attemptuser = $DB->get_record('user', ['id' => $attemptobj->get_userid()]);
             $userpicture = new \user_picture($attemptuser);
             $userpicture->courseid = $attemptobj->get_courseid();

--- a/classes/Report.php
+++ b/classes/Report.php
@@ -393,17 +393,26 @@ class Report {
 
         // Section: Quiz header.
         if ($sections['header']) {
-
             $quizheaderdata = [];
+
+            // User name and link
             $attemptuser = $DB->get_record('user', ['id' => $attemptobj->get_userid()]);
             $userpicture = new \user_picture($attemptuser);
             $userpicture->courseid = $attemptobj->get_courseid();
+            $userlink = new \action_link(
+                new \moodle_url('/user/view.php', ['id' => $attemptuser->id, 'course' => $attemptobj->get_courseid()]),
+                fullname($attemptuser, true)
+            );
+            global $OUTPUT;
             $quizheaderdata['user'] = [
-                'title' => $userpicture,
-                'content' => new \action_link(
-                    new \moodle_url('/user/view.php', ['id' => $attemptuser->id, 'course' => $attemptobj->get_courseid()]),
-                    fullname($attemptuser, true)
-                ),
+                'title' => get_string('user'),
+                'content' => $OUTPUT->render($userpicture) . '&nbsp;' . $OUTPUT->render($userlink),
+            ];
+
+            // User ID number.
+            $quizheaderdata['useridnumber'] = [
+                'title' => get_string('idnumber'),
+                'content' => $attemptuser->idnumber ?: '<i>'.get_string('none').'</i>',
             ];
 
             // Quiz metadata.

--- a/classes/Report.php
+++ b/classes/Report.php
@@ -169,7 +169,7 @@ class Report {
         // Get all requested attempts.
         return $DB->get_records_sql(
             "SELECT qa.id AS attemptid, qa.userid, qa.attempt, qa.state, qa.timestart, qa.timefinish, ".
-            "       u.username, u.firstname, u.lastname ".
+            "       u.username, u.firstname, u.lastname, u.idnumber ".
             "FROM {quiz_attempts} qa LEFT JOIN {user} u ON qa.userid = u.id ".
             "WHERE qa.preview = 0 AND qa.quiz = :quizid " . ($filterwhereclause ?? ''),
             [

--- a/classes/Report.php
+++ b/classes/Report.php
@@ -503,7 +503,7 @@ class Report {
                 $feedback = $attemptobj->get_overall_feedback($grade);
                 $quizheaderdata['feedback'] = [
                     'title' => get_string('feedback', 'quiz'),
-                    'content' => $feedback,
+                    'content' => $feedback ?: '<i>'.get_string('none').'</i>',
                 ];
             }
 

--- a/classes/external/get_attempts_metadata.php
+++ b/classes/external/get_attempts_metadata.php
@@ -129,6 +129,11 @@ class get_attempts_metadata extends external_api {
                         'Last name for this quiz attempt',
                         VALUE_REQUIRED
                     ),
+                    'idnumber' => new external_value(
+                        PARAM_TEXT,
+                        'ID number of the user for this quiz attempt',
+                        VALUE_REQUIRED
+                    ),
                     'timestart' => new external_value(
                         PARAM_INT,
                         'Timestamp of when the quiz attempt started',

--- a/docs/development/unittests.md
+++ b/docs/development/unittests.md
@@ -48,7 +48,7 @@ you can run the tests using the following commands:
   ```
 - Running a single test suite:
   ```text
-  vendor/bin/phpunit --colors --testdox mod/quiz/report/archiver/tests/Report_test.php
+  vendor/bin/phpunit --colors --testdox mod/quiz/report/archiver/tests/report_test.php
   ```
   
 !!! warning

--- a/lang/de/quiz_archiver.php
+++ b/lang/de/quiz_archiver.php
@@ -134,6 +134,7 @@ $string['export_attempts_filename_pattern_variable_attemptid'] = 'Versuchs-ID';
 $string['export_attempts_filename_pattern_variable_username'] = 'Nutzer Anmeldename';
 $string['export_attempts_filename_pattern_variable_firstname'] = 'Nutzer Vorname';
 $string['export_attempts_filename_pattern_variable_lastname'] = 'Nutzer Nachname';
+$string['export_attempts_filename_pattern_variable_idnumber'] = 'Nutzer ID-Nummer';
 $string['export_attempts_filename_pattern_variable_timestart'] = 'Versuchsstart (Unix-Zeitstempel)';
 $string['export_attempts_filename_pattern_variable_timefinish'] = 'Versuchsende (Unix-Zeitstempel)';
 $string['export_attempts_filename_pattern_variable_date'] = 'Aktuelles Datum <small>(YYYY-MM-DD)</small>';

--- a/lang/en/quiz_archiver.php
+++ b/lang/en/quiz_archiver.php
@@ -134,6 +134,7 @@ $string['export_attempts_filename_pattern_variable_attemptid'] = 'Attempt ID';
 $string['export_attempts_filename_pattern_variable_username'] = 'Student username';
 $string['export_attempts_filename_pattern_variable_firstname'] = 'Student first name';
 $string['export_attempts_filename_pattern_variable_lastname'] = 'Student last name';
+$string['export_attempts_filename_pattern_variable_idnumber'] = 'Student ID number';
 $string['export_attempts_filename_pattern_variable_timestart'] = 'Attempt start unix timestamp';
 $string['export_attempts_filename_pattern_variable_timefinish'] = 'Attempt finish unix timestamp';
 $string['export_attempts_filename_pattern_variable_date'] = 'Current date <small>(YYYY-MM-DD)</small>';

--- a/tests/report_test.php
+++ b/tests/report_test.php
@@ -578,6 +578,7 @@ final class report_test extends \advanced_testcase {
         $this->assertNotEmpty($attempt->username, 'Attempt metadata does not contain username');
         $this->assertNotEmpty($attempt->firstname, 'Attempt metadata does not contain firstname');
         $this->assertNotEmpty($attempt->lastname, 'Attempt metadata does not contain lastname');
+        $this->assertNotNull($attempt->idnumber, 'Attempt metadata does not contain idnumber');  // ID number can be empty.
 
         // Test filtered.
         $attemptsfilteredexisting = $report->get_attempts_metadata($rc->attemptids);


### PR DESCRIPTION
- Add student ID number to quiz attempt header (fixes #49)
- Add student ID number to exported `attempts_metadata.csv` file inside quiz archives (fixes #49)
- Allow student ID number to be used in attempt filename pattern as `${idnumber}` (fixes #33)
- Improve display of user firstname, lastname, and avatar in quiz attempt header
- Improve display of empty values in quiz attempt header (e.g., feedback, idnumber, ...)
- Fix single unit test suit execution command in developer documentation
