### PR TITLE
Fix: Archive filename duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add student ID number to quiz attempt header
 - Add student ID number to exported `attempts_metadata.csv` file inside quiz archives
 - Allow student ID number to be used in attempt filename pattern as `${idnumber}`
+- Fix creation of quiz archives with duplicate archive names (e.g., when using `quiz-archive-${quizid}-${quizname}` as the archive name pattern)
 - Improve display of user firstname, lastname, and avatar in quiz attempt header
 - Improve display of empty values in quiz attempt header (e.g., feedback, idnumber, ...)
 - Fix name of `QUIZ_ARCHIVER_PREVENT_REDIRECT_TO_LOGIN` environment variable in archive worker documentation

--- a/classes/FileManager.php
+++ b/classes/FileManager.php
@@ -122,13 +122,15 @@ class FileManager {
      *
      * @param stored_file $draftfile Archive artifact file, residing inside
      * 'draft' filearea of the webservice user
+     * @param int $jobid Internal ID of the job this artifact belongs to. Used
+     * as itemid for the new stored file
      *
      * @return stored_file|null Stored file on success, null on error
      *
      * @throws \file_exception
      * @throws \stored_file_creation_exception
      */
-    public function store_uploaded_artifact(stored_file $draftfile): ?stored_file {
+    public function store_uploaded_artifact(stored_file $draftfile, int $jobid): ?stored_file {
         // Check draftfile.
         if ($draftfile->get_filearea() != "draft" || $draftfile->get_component() != "user") {
             throw new \file_exception('Passed draftfile does not reside inside the draft area of the webservice user. Aborting');
@@ -140,7 +142,7 @@ class FileManager {
             'contextid'    => $this->context->id,
             'component'    => self::COMPONENT_NAME,
             'filearea'     => self::ARTIFACTS_FILEAREA_NAME,
-            'itemid'       => 0,
+            'itemid'       => $jobid,
             'filepath'     => $this->get_own_file_path(),
             'filename'     => $draftfile->get_filename(),
             'timecreated'  => $draftfile->get_timecreated(),

--- a/classes/external/process_uploaded_artifact.php
+++ b/classes/external/process_uploaded_artifact.php
@@ -207,7 +207,7 @@ class process_uploaded_artifact extends external_api {
         // Store uploaded file.
         $fm = new FileManager($job->get_courseid(), $job->get_cmid(), $job->get_quizid());
         try {
-            $artifact = $fm->store_uploaded_artifact($draftfile);
+            $artifact = $fm->store_uploaded_artifact($draftfile, $job->get_id());
             $job->link_artifact($artifact->get_id(), $params['artifact_sha256sum']);
         } catch (\Exception $e) {
             $job->set_status(ArchiveJob::STATUS_FAILED);

--- a/tests/filemanager_test.php
+++ b/tests/filemanager_test.php
@@ -135,7 +135,7 @@ final class filemanager_test extends \advanced_testcase {
         $draftfilehash = $draftfile->get_contenthash();
 
         // Store draftfile as artifact.
-        $storedfile = $fm->store_uploaded_artifact($draftfile);
+        $storedfile = $fm->store_uploaded_artifact($draftfile, 42);
         $this->assertInstanceOf(\stored_file::class, $storedfile, 'Invalid storage handle returned');
         $this->assertEquals($draftfilehash, $storedfile->get_contenthash(), 'Stored file hash does not match draft file hash');
         $this->assertEmpty(get_file_storage()->get_file_by_id($draftfile->get_id()), 'Draft file was deleted');
@@ -163,7 +163,7 @@ final class filemanager_test extends \advanced_testcase {
 
         $this->expectException(\file_exception::class);
         $this->expectExceptionMessageMatches('/draftfile/');
-        $fm->store_uploaded_artifact($invalidfile);
+        $fm->store_uploaded_artifact($invalidfile, 1337);
     }
 
     /**
@@ -562,7 +562,7 @@ final class filemanager_test extends \advanced_testcase {
         $attemptid = 13775;
 
         $fm = new FileManager($mocks->course->id, $mocks->quiz->cmid, $mocks->quiz->id);
-        $fm->store_uploaded_artifact($draftartifact);
+        $fm->store_uploaded_artifact($draftartifact, $job->get_id());
         $storedartifacts = $fm->get_stored_artifacts();
         $storedartifact = array_shift($storedartifacts);
 
@@ -603,7 +603,7 @@ final class filemanager_test extends \advanced_testcase {
         );
         $draftartifact = $this->getDataGenerator()->import_reference_quiz_artifact_as_draft();
         $fm = new FileManager($mocks->course->id, $mocks->quiz->cmid, $mocks->quiz->id);
-        $fm->store_uploaded_artifact($draftartifact);
+        $fm->store_uploaded_artifact($draftartifact, $job->get_id());
         $storedartifacts = $fm->get_stored_artifacts();
         $storedartifact = array_shift($storedartifacts);
 


### PR DESCRIPTION
This PR addresses #55 

- Fix creation of quiz archives with duplicate archive names (e.g., when using `quiz-archive-${quizid}-${quizname}` as the archive name pattern)
