### PR TITLE
Set base-path for Coveralls report to reduce source tree complexity

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -161,6 +161,7 @@ jobs:
         with:
           format: clover
           file: coverage.xml
+          base-path: moodle/mod/quiz/report/archiver
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mark cancelled jobs as failed.


### PR DESCRIPTION
This PR aims to improve the Coveralls code coverage report by removing the base Moodle path from the reports.