### PR TITLE
Fix: Autoinstall service account users are created with wrong mnethostid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version X.Y.Z (YYYYMMDDXX)
+
+- Fix autoinstall not setting `mnethostid` to local host when creating the service account user
+
+
 ## Version 3.1.0 (2025041900)
 
 - Switch from `.tar.gz` to `.zip` format for quiz archives

--- a/classes/local/autoinstall.php
+++ b/classes/local/autoinstall.php
@@ -118,6 +118,8 @@ class autoinstall {
         string $username = self::DEFAULT_USERNAME,
         bool $force = false
     ): array {
+        global $CFG;
+
         // Prepare return values.
         $success = false;
 
@@ -183,6 +185,7 @@ class autoinstall {
                     'confirmed' => 1,
                     'deleted' => 0,
                     'policyagreed' => 1,
+                    'mnethostid' => $CFG->mnet_localhost_id,
                 ]);
                 $webserviceuser = \core_user::get_user($webserviceuserid);
                 $log[] = "  -> Web service user '{$webserviceuser->username}' with ID {$webserviceuser->id} created.";

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -39,7 +39,7 @@ defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
  * @throws upgrade_exception
  */
 function xmldb_quiz_archiver_upgrade($oldversion) {
-    global $DB;
+    global $CFG, $DB;
 
     $dbman = $DB->get_manager();
 
@@ -246,6 +246,23 @@ function xmldb_quiz_archiver_upgrade($oldversion) {
 
         // Archiver savepoint reached.
         upgrade_plugin_savepoint(true, 2025040200, 'quiz', 'archiver');
+    }
+
+    if ($oldversion < 2025042800) {
+        // Ensure service account users have a local mnethostid record.
+        $webserviceuserid = get_config('quiz_archiver', 'webservice_userid');
+        if ($webserviceuserid) {
+            $user = $DB->get_record('user', ['id' => $webserviceuserid]);
+            if ($user && $user->mnethostid == 0) {
+                $DB->update_record('user', [
+                    'id' => $user->id,
+                    'mnethostid' => $CFG->mnet_localhost_id,
+                ]);
+            }
+        }
+
+        // Archiver savepoint reached.
+        upgrade_plugin_savepoint(true, 2025042800, 'quiz', 'archiver');
     }
 
     return true;

--- a/tests/local/autoinstall_test.php
+++ b/tests/local/autoinstall_test.php
@@ -52,7 +52,7 @@ final class autoinstall_test extends \advanced_testcase {
      * @throws \dml_exception
      */
     public function test_autoinstall(): void {
-        global $DB;
+        global $CFG, $DB;
         $this->resetAfterTest();
 
         // Gain privileges.
@@ -120,6 +120,7 @@ final class autoinstall_test extends \advanced_testcase {
             'User role was not assigned'
         );
         $this->assertSame($user->id, get_config('quiz_archiver', 'webservice_userid'), 'User ID was not set correctly');
+        $this->assertEquals($user->mnethostid, $CFG->mnet_localhost_id, 'User was not created on localhost');
     }
 
     /**


### PR DESCRIPTION
This PR addresses the problem of #75.

It fixes the issue for new installations and patches existing ones. The respective unit test is extended to cover this case.