### PR TITLE
Fix: Attempt report unit tests for Moodle version >= 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version X.Y.Z (YYYYMMDDXX)
 
 - Fix Moodle CSS stylelint errors for mkdocs extra CSS file to make Moodle plugin directory prechecks happy
+- Fix attempt report generation unit tests for latest Moodle version >= 4.5
 
 
 ## Version 3.1.1 (2025042800)

--- a/tests/report_test.php
+++ b/tests/report_test.php
@@ -156,7 +156,7 @@ final class report_test extends \advanced_testcase {
         // Verify questions.
         foreach ($this->getDataGenerator()::QUESTION_TYPES_IN_REFERENCE_QUIZ as $qtype) {
             $this->assertMatchesRegularExpression(
-                '/<[^<>]*class="[^\"<>]*que[^\"<>]*' . preg_quote($qtype, '/') . '[^\"<>]*"[^<>]*>/',
+                '/<[^<>]*class="[^"<>]*que[^"<>]*' . preg_quote($qtype, '/') . '[^"<>]*"[^<>]*>/',
                 $html,
                 'Question of type ' . $qtype . ' not found'
             );
@@ -164,28 +164,28 @@ final class report_test extends \advanced_testcase {
 
         // Verify individual question feedback.
         $this->assertMatchesRegularExpression(
-            '/<div class="specificfeedback">/',
+            '/<div [^<>]*class="[^<>"]*specificfeedback[^<>"]*"[^<>]*>/',
             $html,
             'Individual question feedback not found'
         );
 
         // Verify general question feedback.
         $this->assertMatchesRegularExpression(
-            '/<div class="generalfeedback">/',
+            '/<div [^<>]*class="[^<>"]*generalfeedback[^<>"]*"[^<>]*>/',
             $html,
             'General question feedback not found'
         );
 
         // Verify correct answers.
         $this->assertMatchesRegularExpression(
-            '/<div class="rightanswer">/',
+            '/<div [^<>]*class="[^<>"]*rightanswer[^<>"]*"[^<>]*>/',
             $html,
             'Correct question answers not found'
         );
 
         // Verify answer history.
         $this->assertMatchesRegularExpression(
-            '/<[^<>]*class="responsehistoryheader[^\"<>]*"[^<>]*>/',
+            '/<[^<>]*class="responsehistoryheader[^<>"]*"[^<>]*>/',
             $html,
             'Answer history not found'
         );
@@ -322,22 +322,22 @@ final class report_test extends \advanced_testcase {
 
         // If questions are disabled, question_feedback, general_feedback, rightanswer and history should be absent.
         $this->assertDoesNotMatchRegularExpression(
-            '/<div class="specificfeedback">/',
+            '/<div [^<>]*class="[^<>"]*specificfeedback[^<>"]*"[^<>]*>/',
             $html,
             'Individual question feedback found when it should be absent'
         );
         $this->assertDoesNotMatchRegularExpression(
-            '/<div class="generalfeedback">/',
+            '/<div [^<>]*class="[^<>"]*generalfeedback[^<>"]*"[^<>]*>/',
             $html,
             'General question feedback found when it should be absent'
         );
         $this->assertDoesNotMatchRegularExpression(
-            '/<div class="rightanswer">/',
+            '/<div [^<>]*class="[^<>"]*rightanswer[^<>"]*"[^<>]*>/',
             $html,
             'Correct question answers found when they should be absent'
         );
         $this->assertDoesNotMatchRegularExpression(
-            '/<[^<>]*class="responsehistoryheader[^\"<>]*"[^<>]*>/',
+            '/<div [^<>]*class="[^<>"]*responsehistoryheader[^<>"]*"[^<>]*>/',
             $html,
             'Answer history found when it should be absent'
         );
@@ -367,7 +367,7 @@ final class report_test extends \advanced_testcase {
 
         // Verify that question feedback is absent.
         $this->assertDoesNotMatchRegularExpression(
-            '/<div class="specificfeedback">/',
+            '/<div [^<>]*class="[^<>"]*specificfeedback[^<>"]*"[^<>]*>/',
             $html,
             'Individual question feedback found when it should be absent'
         );
@@ -397,7 +397,7 @@ final class report_test extends \advanced_testcase {
 
         // Verify that general feedback is absent.
         $this->assertDoesNotMatchRegularExpression(
-            '/<div class="generalfeedback">/',
+            '/<div [^<>]*class="[^<>"]*generalfeedback[^<>"]*"[^<>]*>/',
             $html,
             'General question feedback found when it should be absent'
         );
@@ -427,7 +427,7 @@ final class report_test extends \advanced_testcase {
 
         // Verify that right answers are absent.
         $this->assertDoesNotMatchRegularExpression(
-            '/<div class="rightanswer">/',
+            '/<div [^<>]*class="[^<>"]*rightanswer[^<>"]*"[^<>]*>/',
             $html,
             'Correct question answers found when they should be absent'
         );
@@ -457,7 +457,7 @@ final class report_test extends \advanced_testcase {
 
         // Verify that answer history is absent.
         $this->assertDoesNotMatchRegularExpression(
-            '/<[^<>]*class="responsehistoryheader[^\"<>]*"[^<>]*>/',
+            '/<div [^<>]*class="[^<>"]*responsehistoryheader[^<>"]*"[^<>]*>/',
             $html,
             'Answer history found when it should be absent'
         );

--- a/tests/report_test.php
+++ b/tests/report_test.php
@@ -24,8 +24,6 @@
 
 namespace quiz_archiver;
 
-use backup;
-
 // @codingStandardsIgnoreLine
 global $CFG;
 


### PR DESCRIPTION
Since a weekly release of Moodle 4.5 and up, a second `clearfix` class seems to be present in some of the attempt report headers. This causes the regex in `tests/report_test.php` to fail.

Example of HTML output:
```html
<div class="specificfeedback clearfix">...</div>
```

This PR modifies the regex patterns to allow for additional classes to be present during matching.