### PR TITLE
Fix: Slashes in filename pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version X.Y.Z (YYYYMMDDNN)
+
+- Fix archive job creation for quizzes with forward slashes in names when the `${quizname}` variable is used
+
+
 ## Version 3.1.2 (2025051700)
 
 - Fix Moodle CSS stylelint errors for mkdocs extra CSS file to make Moodle plugin directory prechecks happy

--- a/classes/ArchiveJob.php
+++ b/classes/ArchiveJob.php
@@ -138,7 +138,7 @@ class ArchiveJob {
     public const FOLDERNAME_FORBIDDEN_CHARACTERS = ["\\", ".", ":", ";", "*", "?", "!", "\"", "<", ">", "|", "\0"];
 
     /** @var string[] Characters that are forbidden in a filename pattern */
-    public const FILENAME_FORBIDDEN_CHARACTERS = self::FOLDERNAME_FORBIDDEN_CHARACTERS + ["/"];
+    public const FILENAME_FORBIDDEN_CHARACTERS = ["\\", ".", ":", ";", "*", "?", "!", "\"", "<", ">", "|", "\0", "/"];
 
     /**
      * Creates a new ArchiveJob. This does **NOT** enqueue the job anywhere.

--- a/tests/archivejob_test.php
+++ b/tests/archivejob_test.php
@@ -1046,6 +1046,10 @@ final class archivejob_test extends \advanced_testcase {
                 'pattern' => 'quiz-archive: foo!bar',
                 'isvalid' => false,
             ],
+            'Slashes' => [
+                'pattern' => 'foo/bar',
+                'isvalid' => false,
+            ],
             'Only invalid characters' => [
                 'pattern' => '.!',
                 'isvalid' => false,
@@ -1192,6 +1196,10 @@ final class archivejob_test extends \advanced_testcase {
             ],
             'Forbidden characters' => [
                 'pattern' => 'attempt: foo!bar',
+                'isvalid' => false,
+            ],
+            'Slashes' => [
+                'pattern' => 'foo/bar',
                 'isvalid' => false,
             ],
             'Only invalid characters' => [


### PR DESCRIPTION
This PR addresses #79 by fixing the removal of forward slashes in filename pattern.