### PR TITLE
Make capability names respect component naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version X.Y.Z (YYYYMMDDXX)
 
 - Ensure compatibility with Moodle 5.1
+- Fix naming of capabilities and migrate old capability assignments to renamed capabilities during upgrade. No manual action is required.
 - Add Moodle 5.1 and all supported PHP versions to CI test matrix
 - Comply with Moodle coding style version 3.6
 

--- a/classes/external/generate_attempt_report.php
+++ b/classes/external/generate_attempt_report.php
@@ -251,7 +251,7 @@ class generate_attempt_report extends external_api {
         } catch (\dml_exception $e) {
             throw new \invalid_parameter_exception("No module context with given cmid found");
         }
-        require_capability('mod/quiz_archiver:use_webservice', $context);
+        require_capability('quiz/archiver:use_webservice', $context);
 
         // Acquire required data objects.
         if (!$course = $DB->get_record('course', ['id' => $params['courseid']])) {

--- a/classes/external/get_attempts_metadata.php
+++ b/classes/external/get_attempts_metadata.php
@@ -217,7 +217,7 @@ class get_attempts_metadata extends external_api {
         } catch (\dml_exception $e) {
             throw new \invalid_parameter_exception("No module context with given cmid found");
         }
-        require_capability('mod/quiz_archiver:use_webservice', $context);
+        require_capability('quiz/archiver:use_webservice', $context);
 
         // Acquire required data objects.
         if (!$course = $DB->get_record('course', ['id' => $params['courseid']])) {

--- a/classes/external/get_backup_status.php
+++ b/classes/external/get_backup_status.php
@@ -109,7 +109,7 @@ class get_backup_status extends external_api {
 
         // Check capabilities.
         $context = \context_module::instance($job->get_cmid());
-        require_capability('mod/quiz_archiver:use_webservice', $context);
+        require_capability('quiz/archiver:use_webservice', $context);
 
         // The following code is tested covered by more specific tests.
         // @codingStandardsIgnoreLine

--- a/classes/external/process_uploaded_artifact.php
+++ b/classes/external/process_uploaded_artifact.php
@@ -173,7 +173,7 @@ class process_uploaded_artifact extends external_api {
 
         // Check capabilities.
         $context = \context_module::instance($job->get_cmid());
-        require_capability('mod/quiz_archiver:use_webservice', $context);
+        require_capability('quiz/archiver:use_webservice', $context);
 
         // Validate uploaded file.
         // Note: We use SHA256 instead of Moodle sha1, since SHA1 is prone to.

--- a/classes/external/update_job_status.php
+++ b/classes/external/update_job_status.php
@@ -106,7 +106,7 @@ class update_job_status extends external_api {
 
             // Check capabilities.
             $context = \context_module::instance($job->get_cmid());
-            require_capability('mod/quiz_archiver:use_webservice', $context);
+            require_capability('quiz/archiver:use_webservice', $context);
 
             if ($job->is_complete()) {
                 return [

--- a/classes/local/autoinstall.php
+++ b/classes/local/autoinstall.php
@@ -54,7 +54,6 @@ class autoinstall {
         'mod/quiz:reviewmyattempts',
         'mod/quiz:view',
         'mod/quiz:viewreports',
-        'mod/quiz_archiver:use_webservice',
         'moodle/backup:anonymise',
         'moodle/backup:backupactivity',
         'moodle/backup:backupcourse',
@@ -69,6 +68,7 @@ class autoinstall {
         'moodle/course:viewhiddencourses',
         'moodle/course:viewhiddensections',
         'moodle/user:ignoreuserquota',
+        'quiz/archiver:use_webservice',
         'webservice/rest:use',
     ];
 

--- a/db/access.php
+++ b/db/access.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
 
 $capabilities = [
     // Capability to view the quiz archiver report page.
-    'mod/quiz_archiver:view' => [
+    'quiz/archiver:view' => [
         'riskbitmask' => (RISK_PERSONAL),
         'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
@@ -37,9 +37,10 @@ $capabilities = [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
         ],
+        'clonepermissionsfrom' => 'mod/quiz_archiver:view',
     ],
-    // Capability to create and delete quiz archives.
-    'mod/quiz_archiver:create' => [
+    // Capability to create quiz archives.
+    'quiz/archiver:create' => [
         'riskbitmask' => (RISK_PERSONAL),
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
@@ -47,9 +48,10 @@ $capabilities = [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
         ],
+        'clonepermissionsfrom' => 'mod/quiz_archiver:create',
     ],
     // Capability to delete quiz archives.
-    'mod/quiz_archiver:delete' => [
+    'quiz/archiver:delete' => [
         'riskbitmask' => (RISK_DATALOSS),
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
@@ -57,12 +59,33 @@ $capabilities = [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
         ],
+        'clonepermissionsfrom' => 'mod/quiz_archiver:delete',
     ],
     // Capability to use the webservice. Required for the webservice user.
-    'mod/quiz_archiver:use_webservice' => [
+    'quiz/archiver:use_webservice' => [
         'riskbitmask' => (RISK_PERSONAL | RISK_DATALOSS),
         'captype' => 'write',
         'contextlevel' => CONTEXT_SYSTEM,
         'archetypes' => [],
+        'clonepermissionsfrom' => 'mod/quiz_archiver:use_webservice',
+    ],
+];
+
+$dedeprecatedcapabilities = [
+    'mod/quiz_archiver:view' => [
+        'replacement' => 'quiz/archiver:view',
+        'message' => 'This capability has been deprecated, please use quiz/archiver:view instead.',
+    ],
+    'mod/quiz_archiver:create' => [
+        'replacement' => 'quiz/archiver:create',
+        'message' => 'This capability has been deprecated, please use quiz/archiver:create instead.',
+    ],
+    'mod/quiz_archiver:delete' => [
+        'replacement' => 'quiz/archiver:delete',
+        'message' => 'This capability has been deprecated, please use quiz/archiver:delete instead.',
+    ],
+    'mod/quiz_archiver:use_webservice' => [
+        'replacement' => 'quiz/archiver:use_webservice',
+        'message' => 'This capability has been deprecated, please use quiz/archiver:use_webservice instead.',
     ],
 ];

--- a/db/services.php
+++ b/db/services.php
@@ -33,7 +33,7 @@ $functions = [
         'type' => 'read',
         'ajax' => true,
         'services' => [],
-        'capabilities' => 'mod/quiz_archiver:use_webservice',
+        'capabilities' => 'quiz/archiver:use_webservice',
     ],
     'quiz_archiver_get_attempts_metadata' => [
         'classname' => 'quiz_archiver\external\get_attempts_metadata',
@@ -41,7 +41,7 @@ $functions = [
         'type' => 'read',
         'ajax' => true,
         'services' => [],
-        'capabilities' => 'mod/quiz_archiver:use_webservice',
+        'capabilities' => 'quiz/archiver:use_webservice',
     ],
     'quiz_archiver_update_job_status' => [
         'classname' => 'quiz_archiver\external\update_job_status',
@@ -49,7 +49,7 @@ $functions = [
         'type' => 'write',
         'ajax' => true,
         'services' => [],
-        'capabilities' => 'mod/quiz_archiver:use_webservice',
+        'capabilities' => 'quiz/archiver:use_webservice',
     ],
     'quiz_archiver_process_uploaded_artifact' => [
         'classname' => 'quiz_archiver\external\process_uploaded_artifact',
@@ -57,7 +57,7 @@ $functions = [
         'type' => 'write',
         'ajax' => true,
         'services' => [],
-        'capabilities' => 'mod/quiz_archiver:use_webservice',
+        'capabilities' => 'quiz/archiver:use_webservice',
     ],
     'quiz_archiver_get_backup_status' => [
         'classname' => 'quiz_archiver\external\get_backup_status',
@@ -65,6 +65,6 @@ $functions = [
         'type' => 'read',
         'ajax' => true,
         'services' => [],
-        'capabilities' => 'mod/quiz_archiver:use_webservice',
+        'capabilities' => 'quiz/archiver:use_webservice',
     ],
 ];

--- a/docs/configuration/capabilities.md
+++ b/docs/configuration/capabilities.md
@@ -7,11 +7,11 @@ access to its features.
 The following capabilities are introduced by the plugin and required for the
 listed actions:
 
-| Capability                         | Context | Default assignments                    | Description                                                                                                                                                                   |
-|------------------------------------|---------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `mod/quiz_archiver:view`           | Module  | `teacher`, `editingteacher`, `manager` | Required to view the quiz archiver overview page. It allows to download all created archives but does not allow do create new or delete existing archives (read-only access). |
-| `mod/quiz_archiver:create`         | Module  | `editingteacher`, `manager`            | Allows creation of new quiz archives.                                                                                                                                         |
-| `mod/quiz_archiver:delete`         | Module  | `editingteacher`, `manager`            | Allows deletion of existing quiz archives.                                                                                                                                    |
-| `mod/quiz_archiver:use_webservice` | System  | *None*                                 | Required to use any of this plugins webservice functions. The webservice user[^1] needs to have this capability in order to create new quiz archives.                         |
+| Capability                     | Context | Default assignments                    | Description                                                                                                                                                                   |
+|--------------------------------|---------|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `quiz/archiver:view`           | Module  | `teacher`, `editingteacher`, `manager` | Required to view the quiz archiver overview page. It allows to download all created archives but does not allow do create new or delete existing archives (read-only access). |
+| `quiz/archiver:create`         | Module  | `editingteacher`, `manager`            | Allows creation of new quiz archives.                                                                                                                                         |
+| `quiz/archiver:delete`         | Module  | `editingteacher`, `manager`            | Allows deletion of existing quiz archives.                                                                                                                                    |
+| `quiz/archiver:use_webservice` | System  | *None*                                 | Required to use any of this plugins webservice functions. The webservice user[^1] needs to have this capability in order to create new quiz archives.                         |
 
 [^1]: The webservice user is created during the [initial plugin configuration](/configuration).

--- a/lang/de/quiz_archiver.php
+++ b/lang/de/quiz_archiver.php
@@ -34,9 +34,14 @@ $string['go_to_plugin_settings'] = 'Plugin-Einstellungen öffnen';
 $string['manual_configuration_continue'] = 'Um alle Plugin-Einstellungen manuell zu setzen, verwenden Sie die Schaltfläche "Weiter" am Ende dieser Seite.';
 
 // Capabilities.
-$string['quiz_archiver:view'] = 'Quiz Archiver Seite anzeigen';
-$string['quiz_archiver:archive'] = 'Erstellen und Löschen von Testarchiven';
+$string['archiver:create'] = 'Erstellen von Testarchiven';
+$string['archiver:delete'] = 'Löschen von Testarchiven';
+$string['archiver:use_webservice'] = 'Webservice des Quiz Archivers nutzen (lesend und schreibend)';
+$string['archiver:view'] = 'Testarchive anzeigen';
+$string['quiz_archiver:create'] = 'Erstellen von Testarchiven';
+$string['quiz_archiver:delete'] = 'Löschen von Testarchiven';
 $string['quiz_archiver:use_webservice'] = 'Webservice des Quiz Archivers nutzen (lesend und schreibend)';
+$string['quiz_archiver:view'] = 'Testarchive anzeigen';
 
 // General.
 $string['a'] = '{$a}';

--- a/lang/en/quiz_archiver.php
+++ b/lang/en/quiz_archiver.php
@@ -34,9 +34,14 @@ $string['go_to_plugin_settings'] = 'Go to plugin settings';
 $string['manual_configuration_continue'] = 'To manually configure all plugin settings use the "Continue" button at the bottom of this page.';
 
 // Capabilities.
-$string['quiz_archiver:view'] = 'View quiz archiver page';
-$string['quiz_archiver:archive'] = 'Create and delete quiz archives';
+$string['archiver:create'] = 'Create quiz archives';
+$string['archiver:delete'] = 'Delete quiz archives';
+$string['archiver:use_webservice'] = 'Use the quiz archiver webservice (read and write)';
+$string['archiver:view'] = 'View quiz archiver page';
+$string['quiz_archiver:create'] = 'Create quiz archives';
+$string['quiz_archiver:delete'] = 'Delete quiz archives';
 $string['quiz_archiver:use_webservice'] = 'Use the quiz archiver webservice (read and write)';
+$string['quiz_archiver:view'] = 'View quiz archiver page';
 
 // General.
 $string['a'] = '{$a}';

--- a/report.php
+++ b/report.php
@@ -98,7 +98,7 @@ class quiz_archiver_report extends report_base {
 
         // Check permissions.
         $this->context = context_module::instance($cm->id);
-        require_capability('mod/quiz_archiver:view', $this->context);
+        require_capability('quiz/archiver:view', $this->context);
 
         // Handle forms before output starts.
         $formhtml = $this->handle_posted_forms();
@@ -270,7 +270,7 @@ class quiz_archiver_report extends report_base {
         global $CFG, $USER;
 
         // Check permissions.
-        require_capability('mod/quiz_archiver:create', $this->context);
+        require_capability('quiz/archiver:create', $this->context);
 
         // Check if webservice is configured properly.
         if (autoinstall::plugin_is_unconfigured()) {
@@ -423,7 +423,7 @@ class quiz_archiver_report extends report_base {
 
             if ($jobdeleteform->is_submitted()) {
                 // Check permissions.
-                require_capability('mod/quiz_archiver:delete', $this->context);
+                require_capability('quiz/archiver:delete', $this->context);
 
                 // Execute deletion.
                 $formdata = $jobdeleteform->get_data();
@@ -450,7 +450,7 @@ class quiz_archiver_report extends report_base {
 
             if ($artifactdeleteform->is_submitted()) {
                 // Check permissions.
-                require_capability('mod/quiz_archiver:delete', $this->context);
+                require_capability('quiz/archiver:delete', $this->context);
 
                 // Execute deletion.
                 $formdata = $artifactdeleteform->get_data();
@@ -477,7 +477,7 @@ class quiz_archiver_report extends report_base {
 
             if ($jobsignform->is_submitted()) {
                 // Check permissions.
-                require_capability('mod/quiz_archiver:create', $this->context);
+                require_capability('quiz/archiver:create', $this->context);
 
                 // Execute signing.
                 $formdata = $jobsignform->get_data();

--- a/res/moodle_role_quiz_archiver.xml
+++ b/res/moodle_role_quiz_archiver.xml
@@ -15,7 +15,7 @@
 		<allow>mod/quiz:reviewmyattempts</allow>
 		<allow>mod/quiz:view</allow>
 		<allow>mod/quiz:viewreports</allow>
-		<allow>mod/quiz_archiver:use_webservice</allow>
+		<allow>quiz/archiver:use_webservice</allow>
 		<allow>moodle/backup:anonymise</allow>
 		<allow>moodle/backup:backupactivity</allow>
 		<allow>moodle/backup:backupcourse</allow>

--- a/tests/external/generate_attempt_report_test.php
+++ b/tests/external/generate_attempt_report_test.php
@@ -109,7 +109,7 @@ final class generate_attempt_report_test extends \advanced_testcase {
     public function test_capability_requirement(): void {
         // Check that a user without the required capability is rejected.
         $this->expectException(\required_capability_exception::class);
-        $this->expectExceptionMessageMatches('/.*mod\/quiz_archiver:use_webservice.*/');
+        $this->expectExceptionMessageMatches('/.*' . preg_quote(get_string('archiver:use_webservice', 'quiz_archiver')) . '.*/');
 
         $this->resetAfterTest();
         $mocks = $this->getDataGenerator()->create_mock_quiz();

--- a/tests/external/get_attempts_metadata_test.php
+++ b/tests/external/get_attempts_metadata_test.php
@@ -102,7 +102,7 @@ final class get_attempts_metadata_test extends \advanced_testcase {
     public function test_capability_requirement(): void {
         // Check that a user without the required capability is rejected.
         $this->expectException(\required_capability_exception::class);
-        $this->expectExceptionMessageMatches('/.*mod\/quiz_archiver:use_webservice.*/');
+        $this->expectExceptionMessageMatches('/.*' . preg_quote(get_string('archiver:use_webservice', 'quiz_archiver')) . '.*/');
 
         $this->resetAfterTest();
         $mocks = $this->getDataGenerator()->create_mock_quiz();

--- a/tests/external/get_backup_status_test.php
+++ b/tests/external/get_backup_status_test.php
@@ -70,7 +70,7 @@ final class get_backup_status_test extends \advanced_testcase {
 
         // Check that a user without the required capability is rejected.
         $this->expectException(\required_capability_exception::class);
-        $this->expectExceptionMessageMatches('/.*mod\/quiz_archiver:use_webservice.*/');
+        $this->expectExceptionMessageMatches('/.*' . preg_quote(get_string('archiver:use_webservice', 'quiz_archiver')) . '.*/');
         get_backup_status::execute($job->get_jobid(), 'f1d2d2f924e986ac86fdf7b36c94bcdf32beec15');
     }
 

--- a/tests/external/process_uploaded_artifact_test.php
+++ b/tests/external/process_uploaded_artifact_test.php
@@ -107,7 +107,7 @@ final class process_uploaded_artifact_test extends \advanced_testcase {
     public function test_capability_requirement(): void {
         // Check that a user without the required capability is rejected.
         $this->expectException(\required_capability_exception::class);
-        $this->expectExceptionMessageMatches('/.*mod\/quiz_archiver:use_webservice.*/');
+        $this->expectExceptionMessageMatches('/.*' . preg_quote(get_string('archiver:use_webservice', 'quiz_archiver')) . '.*/');
 
         // Create job.
         $this->resetAfterTest();

--- a/tests/external/update_job_status_test.php
+++ b/tests/external/update_job_status_test.php
@@ -100,7 +100,7 @@ final class update_job_status_test extends \advanced_testcase {
 
         // Check that a user without the required capability is rejected.
         $this->expectException(\required_capability_exception::class);
-        $this->expectExceptionMessageMatches('/.*mod\/quiz_archiver:use_webservice.*/');
+        $this->expectExceptionMessageMatches('/.*' . preg_quote(get_string('archiver:use_webservice', 'quiz_archiver')) . '.*/');
         update_job_status::execute($job->get_jobid(), ArchiveJob::STATUS_UNINITIALIZED);
     }
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
 
 $plugin->component = 'quiz_archiver';
 $plugin->release = '3.1.3';
-$plugin->version = 2025052200;
+$plugin->version = 2025052201;
 $plugin->requires = 2022112800;
 $plugin->supported = [401, 501];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR makes capability adhere to the Moodle naming conventions. Old capability assignments are automatically migrated to new capabilities during upgrade. The old capabilities are still kept as deprecated capabilities.