### PR TITLE
MBS-10897: Remove obsolete .token.comment inline CSS

### DIFF
--- a/classes/Report.php
+++ b/classes/Report.php
@@ -643,11 +643,6 @@ class Report {
                     overflow: visible !important;
                     white-space: pre-wrap !important;
                 }
-
-                /* Remove padding from codebox comments to prevent them from drawing over student code */
-                code .token.comment {
-                    padding: 0.5rem !important;
-                }
             ");
             $dom->getElementsByTagName('head')[0]->appendChild($csshacksnode);
         }


### PR DESCRIPTION
The inline CSS rule `code .token.comment { padding: 0.5rem !important; }` in `Report::generate_full_page()` is dead code since MDL-80496 was merged into MOODLE_501_STABLE (2026-04-07).

MDL-80496 activated the PrismJS CustomClass plugin, which prefixes all token classes with `prism-`. PrismJS now generates `.prism-token.prism-comment` instead of `.token.comment`, so the selector no longer matches any generated elements.

The other CSS rule in the same block (`pre[class*='language-']` with `overflow: visible` and `white-space: pre-wrap`) remains untouched as it is still active and correct.