### PR TITLE
Feature: Student email metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version X.Y.Z (YYYYMMDDNN)
 
 - Display attempt user email address in attempt report header section
+- Add `${email}` variable to filename patterns. Dots inside email addresses are automatically replaced with underscores.
 
 
 ## Version 5.0.0 (2026081100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version X.Y.Z (YYYYMMDDNN)
+
+- Display attempt user email address in attempt report header section
+
+
 ## Version 5.0.0 (2026081100)
 
 - **🚨 BREAKING 🚨** The companion service was renamed from "Moodle Quiz Archive Worker" to "Moodle Archiving Worker"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Display attempt user email address in attempt report header section
 - Add `${email}` variable to filename patterns. Dots inside email addresses are automatically replaced with underscores.
+- Add email field to exported `attempts_metadata.csv` file inside quiz archives
 
 
 ## Version 5.0.0 (2026081100)

--- a/classes/ArchiveJob.php
+++ b/classes/ArchiveJob.php
@@ -116,6 +116,7 @@ class ArchiveJob {
         'username',
         'firstname',
         'lastname',
+        'email',
         'idnumber',
         'timestart',
         'timefinish',
@@ -1338,6 +1339,7 @@ class ArchiveJob {
             'username' => $userinfo->username ?: 'null',
             'firstname' => $userinfo->firstname ?: 'null',
             'lastname' => $userinfo->lastname ?: 'null',
+            'email' => str_replace('.', '_', $userinfo->email) ?: 'null',
             'idnumber' => $userinfo->idnumber ?: 'null',
         ];
 
@@ -1399,6 +1401,7 @@ class ArchiveJob {
             'username' => $userinfo->username ?: 'null',
             'firstname' => $userinfo->firstname ?: 'null',
             'lastname' => $userinfo->lastname ?: 'null',
+            'email' => str_replace('.', '_', $userinfo->email) ?: 'null',
             'idnumber' => $userinfo->idnumber ?: 'null',
         ];
 

--- a/classes/Report.php
+++ b/classes/Report.php
@@ -219,7 +219,7 @@ class Report {
         // Get all requested attempts.
         return $DB->get_records_sql(
             "SELECT qa.id AS attemptid, qa.userid, qa.attempt, qa.state, qa.timestart, qa.timefinish, " .
-            "       u.username, u.firstname, u.lastname, u.idnumber " .
+            "       u.username, u.firstname, u.lastname, u.email, u.idnumber " .
             "FROM {quiz_attempts} qa LEFT JOIN {user} u ON qa.userid = u.id " .
             "WHERE qa.preview = 0 AND qa.quiz = :quizid " . ($filterwhereclause ?? ''),
             [

--- a/classes/Report.php
+++ b/classes/Report.php
@@ -523,6 +523,13 @@ class Report {
                 $OUTPUT->render($userpicture) . '&nbsp;' . $OUTPUT->render($userlink)
             );
 
+            // User email.
+            $summaryinfo->add_item(
+                'useremail',
+                get_string('email'),
+                $attemptuser->email ?: '<i>' . get_string('none') . '</i>'
+            );
+
             // User ID number.
             $summaryinfo->add_item(
                 'useridnumber',

--- a/classes/external/get_attempts_metadata.php
+++ b/classes/external/get_attempts_metadata.php
@@ -132,6 +132,11 @@ class get_attempts_metadata extends external_api {
                         'Last name for this quiz attempt',
                         VALUE_REQUIRED
                     ),
+                    'email' => new external_value(
+                        PARAM_TEXT,
+                        'Email address for this quiz attempt',
+                        VALUE_REQUIRED
+                    ),
                     'idnumber' => new external_value(
                         PARAM_TEXT,
                         'ID number of the user for this quiz attempt',

--- a/lang/de/quiz_archiver.php
+++ b/lang/de/quiz_archiver.php
@@ -163,6 +163,7 @@ $string['export_attempts_filename_pattern_variable_attemptid'] = 'Versuchs-ID';
 $string['export_attempts_filename_pattern_variable_username'] = 'Nutzer Anmeldename';
 $string['export_attempts_filename_pattern_variable_firstname'] = 'Nutzer Vorname';
 $string['export_attempts_filename_pattern_variable_lastname'] = 'Nutzer Nachname';
+$string['export_attempts_filename_pattern_variable_email'] = 'Nutzer E-Mail (Punkte durch Unterstriche ersetzt)';
 $string['export_attempts_filename_pattern_variable_idnumber'] = 'Nutzer ID-Nummer';
 $string['export_attempts_filename_pattern_variable_timestart'] = 'Versuchsstart (Unix-Zeitstempel)';
 $string['export_attempts_filename_pattern_variable_timefinish'] = 'Versuchsende (Unix-Zeitstempel)';

--- a/lang/en/quiz_archiver.php
+++ b/lang/en/quiz_archiver.php
@@ -163,6 +163,7 @@ $string['export_attempts_filename_pattern_variable_attemptid'] = 'Attempt ID';
 $string['export_attempts_filename_pattern_variable_username'] = 'Student username';
 $string['export_attempts_filename_pattern_variable_firstname'] = 'Student first name';
 $string['export_attempts_filename_pattern_variable_lastname'] = 'Student last name';
+$string['export_attempts_filename_pattern_variable_email'] = 'Student email (dots replaced with underscores)';
 $string['export_attempts_filename_pattern_variable_idnumber'] = 'Student ID number';
 $string['export_attempts_filename_pattern_variable_timestart'] = 'Attempt start unix timestamp';
 $string['export_attempts_filename_pattern_variable_timefinish'] = 'Attempt finish unix timestamp';

--- a/tests/archivejob_test.php
+++ b/tests/archivejob_test.php
@@ -1329,6 +1329,8 @@ final class archivejob_test extends \advanced_testcase {
      * @throws \dml_exception
      */
     public function test_generate_attempt_foldername(): void {
+        global $DB;
+
         // Generate data.
         $this->resetAfterTest();
         $generator = $this->getDataGenerator();
@@ -1355,6 +1357,12 @@ final class archivejob_test extends \advanced_testcase {
         // TODO: (MDL-0) Update reference course to cover groups and check for these.
         $this->assertStringContainsString('nogroup', $foldername, 'Group name placeholder was not found in folder name');
         $this->assertStringContainsString($rc->attemptids[0], $foldername, 'Attempt ID was not found in folder name');
+
+        // Email placeholder must be sanitized (dots replaced with underscores).
+        $attemptinfo = $DB->get_record('quiz_attempts', ['id' => $rc->attemptids[0]], '*', MUST_EXIST);
+        $userinfo = $DB->get_record('user', ['id' => $attemptinfo->userid], '*', MUST_EXIST);
+        $expectedemail = str_replace('.', '_', $userinfo->email);
+        $this->assertStringContainsString($expectedemail, $foldername, 'Email was not found in folder name');
     }
 
     /**
@@ -1454,6 +1462,8 @@ final class archivejob_test extends \advanced_testcase {
      * @throws \dml_exception
      */
     public function test_generate_attempt_filename(): void {
+        global $DB;
+
         // Generate data.
         $this->resetAfterTest();
         $generator = $this->getDataGenerator();
@@ -1480,6 +1490,12 @@ final class archivejob_test extends \advanced_testcase {
         // TODO: (MDL-0) Update reference course to cover groups and check for these.
         $this->assertStringContainsString('nogroup', $filename, 'Group name placeholder was not found in filename');
         $this->assertStringContainsString($rc->attemptids[0], $filename, 'Attempt ID was not found in filename');
+
+        // Email placeholder must be sanitized (dots replaced with underscores).
+        $attemptinfo = $DB->get_record('quiz_attempts', ['id' => $rc->attemptids[0]], '*', MUST_EXIST);
+        $userinfo = $DB->get_record('user', ['id' => $attemptinfo->userid], '*', MUST_EXIST);
+        $expectedemail = str_replace('.', '_', $userinfo->email);
+        $this->assertStringContainsString($expectedemail, $filename, 'Email was not found in filename');
     }
 
     /**

--- a/tests/report_test.php
+++ b/tests/report_test.php
@@ -808,6 +808,7 @@ final class report_test extends \advanced_testcase {
         $this->assertNotEmpty($attempt->username, 'Attempt metadata does not contain username');
         $this->assertNotEmpty($attempt->firstname, 'Attempt metadata does not contain firstname');
         $this->assertNotEmpty($attempt->lastname, 'Attempt metadata does not contain lastname');
+        $this->assertNotEmpty($attempt->email, 'Attempt metadata does not contain email');
         $this->assertNotNull($attempt->idnumber, 'Attempt metadata does not contain idnumber');  // ID number can be empty.
 
         // Test filtered.


### PR DESCRIPTION
This PR contains the following additions for #100 :

- Display attempt user email address in attempt report header section
- Add `${email}` variable to filename patterns. Dots inside email addresses are automatically replaced with underscores.
- Add email field to exported `attempts_metadata.csv` file inside quiz archives
